### PR TITLE
[Chore] #33 CORS설정 추가 후 프론트 단에서 AUTH쪽으로 날아가는 것 확인

### DIFF
--- a/baro-cloud/gateway/src/main/resources/application.yml
+++ b/baro-cloud/gateway/src/main/resources/application.yml
@@ -7,6 +7,14 @@ spring:
 
   cloud:
     gateway:
+      globalcors:
+        corsConfigurations:
+          '[/**]': # 모든 경로에 대해 CORS 허용
+            allowedOrigins: "http://localhost:3000" # 프론트 로컬 도메인(추가 도메인은 콤마로 추가)
+            allowedMethods: "*"   # 허용 HTTP 메서드 (GET/POST/PUT/DELETE 등)
+            allowedHeaders: "*"   # 허용 요청 헤더 (Authorization 등)
+            allowCredentials: true # 쿠키/인증 헤더 전달 허용 시 true
+            maxAge: 3600          # 프리플라이트(OPTIONS) 결과를 캐시할 시간(초)
       discovery:
         locator:
           enabled: true


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요 (예: #123) -->
- #33 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->

프론트 브라우저 회원가입화면에서 email 인증 버튼 클릭시, 게이트 웨어를 통해 auth 서버에서 코드를 발급하는 것을 확인했습니다.

## 🎯 변경된 서비스
<!-- 해당하는 서비스에 체크해주세요 -->
- [ ] auth-service
- [ ] buyer-service
- [ ] cart-service
- [ ] product-service
- [ ] seller-service
- [ ] farm-service
- [ ] order-service
- [ ] payment-service
- [ ] settlement-service
- [ ] delivery-service
- [ ] notification-service
- [ ] experience-service
- [ ] search-service
- [ ] review-service
- [X] gateway-service
- [ ] config-server
- [ ] eureka-server

## ✅ 체크리스트
<!-- 완료한 항목에 체크해주세요 -->
- [X] 린트 검사 통과 (`./gradlew lint`)
- [X] 코드 포맷팅 완료 (`./gradlew format`)
- [X] 테스트 통과 (`./gradlew test`)
- [X] 문서 업데이트 (필요한 경우)

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 💬 리뷰어에게
<!-- 리뷰어가 중점적으로 봐야 할 부분이 있다면 적어주세요 -->

- [ ] 프론트 단과의 연결을 위한 단순 설정과 관련한 작업입니다.
- [ ] 현재 Gateway의 헤더키가 auth 서비스와만 일치되어 있습니다.
- [ ] 따라서, 해당 pr 후에도 브라우저에서 auth 이외로 api호출 시, 에러가 날 수 있습니다. 



