### PR TITLE
Chore/issue-39 단순 헤더이름 변경(통일)

### DIFF
--- a/baro-cloud/gateway/src/main/java/com/barofarm/gateway/filter/AuthenticationFilter.java
+++ b/baro-cloud/gateway/src/main/java/com/barofarm/gateway/filter/AuthenticationFilter.java
@@ -16,12 +16,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
-// application.yml에서 AuthenticationFilters조건이 붙어 있는 경우에 Auth에서
-// 발급 받는 access 토큰의 유효성을 판단하고
-// userEmail, userId, userType 헤더로 내려보내는 필터!
-// X-User-Email이런식으로 한 경우도 있는 것 같은데, 일단은 배포과정에 들어간 Auth-Service에 맞춰서 camel식으로 했습니다.
-// TODO: 다른 분들이랑 논의 후 통일
-
 @Component
 public class AuthenticationFilter extends AbstractGatewayFilterFactory<AuthenticationFilter.Config> {
 
@@ -56,9 +50,14 @@ public class AuthenticationFilter extends AbstractGatewayFilterFactory<Authentic
                 String userType = claims.get("ut", String.class);
 
                 ServerHttpRequest modifiedRequest = request.mutate()
-                    .header("userEmail", email)
-                    .header("userId", userId)
-                    .header("userType", userType)
+                    .headers(h->{
+                        h.remove("X-User-Email");
+                        h.remove("X-User-Id");
+                        h.remove("X-User-Role");
+                    })
+                    .header("X-User-Email", email)
+                    .header("X-User-Id", userId)
+                    .header("X-User-Role", userType)
                     .build();
 
                 return chain.filter(exchange.mutate().request(modifiedRequest).build());


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요 (예: #123) -->
- #39 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->

내부 서버들로 게이트웨어가 보내줄 헤더이름을 통일되게 수정했습니다.

## 🎯 변경된 서비스
<!-- 해당하는 서비스에 체크해주세요 -->
- [ ] auth-service
- [ ] buyer-service
- [ ] cart-service
- [ ] product-service
- [ ] seller-service
- [ ] farm-service
- [ ] order-service
- [ ] payment-service
- [ ] settlement-service
- [ ] delivery-service
- [ ] notification-service
- [ ] experience-service
- [ ] search-service
- [ ] review-service
- [X] gateway-service
- [ ] config-server
- [ ] eureka-server

## ✅ 체크리스트
<!-- 완료한 항목에 체크해주세요 -->
- [ ] 린트 검사 통과 (`./gradlew lint`)
- [ ] 코드 포맷팅 완료 (`./gradlew format`)
- [ ] 테스트 통과 (`./gradlew test`)
- [ ] 문서 업데이트 (필요한 경우)

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 💬 리뷰어에게
<!-- 리뷰어가 중점적으로 봐야 할 부분이 있다면 적어주세요 -->




