### PR TITLE
Chore/ issue -33 서버들 Pedicate 서버명과 일치시키기

### DIFF
--- a/baro-cloud/gateway/src/main/resources/application.yml
+++ b/baro-cloud/gateway/src/main/resources/application.yml
@@ -37,7 +37,6 @@ spring:
                 - Path=/buyer-service/**
               filters:
                 - RewritePath=/buyer-service/(?<segment>.*), /${segment}
-                - AuthenticationFilter
 
             # Seller Service
             - id: seller-service
@@ -46,7 +45,6 @@ spring:
                 - Path=/seller-service/**
               filters:
                 - RewritePath=/seller-service/(?<segment>.*), /${segment}
-                - AuthenticationFilter
 
             # Order Service
             - id: order-service
@@ -55,7 +53,6 @@ spring:
                 - Path=/order-service/**,/api/payments/**
               filters:
                 - RewritePath=/order-service/(?<segment>.*), /${segment}
-                - AuthenticationFilter
 
             # Support Service
             - id: support-service
@@ -64,7 +61,6 @@ spring:
                 - Path=/support-service/**
               filters:
                 - RewritePath=/support-service/(?<segment>.*), /${segment}
-                - AuthenticationFilter
 
             # Auth Service API 문서 프록시
             - id: auth-service-openapi


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요 (예: #123) -->
- #33 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->

Auth 외에, 게이트웨이가 처리할 외부 url양식을 통일했습니다.
original 주소가 가령 /api/v1/farms/{id} 이런식이라면, 
클라이언트가 보내야 하는 주소는 seller-service가 앞에 추가된 seller-service/api/v1/farms/{id}과 같은 식이 됩니다.
즉, 프론트단에서는 seller-service/api/v1/farms/{id} 이 주소로 통신을 해야합니다.

## 🎯 변경된 서비스
<!-- 해당하는 서비스에 체크해주세요 -->
- [ ] auth-service
- [ ] buyer-service
- [ ] cart-service
- [ ] product-service
- [ ] seller-service
- [ ] farm-service
- [ ] order-service
- [ ] payment-service
- [ ] settlement-service
- [ ] delivery-service
- [ ] notification-service
- [ ] experience-service
- [ ] search-service
- [ ] review-service
- [X] gateway-service
- [ ] config-server
- [ ] eureka-server

## ✅ 체크리스트
<!-- 완료한 항목에 체크해주세요 -->
- [X] 린트 검사 통과 (`./gradlew lint`)
- [X] 코드 포맷팅 완료 (`./gradlew format`)
- [ ] 테스트 통과 (`./gradlew test`)
- [ ] 문서 업데이트 (필요한 경우)

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 💬 리뷰어에게
<!-- 리뷰어가 중점적으로 봐야 할 부분이 있다면 적어주세요 -->

