### PR TITLE
Chore/issue-48 Security내 permit항목에 /api/v1/ prefix 추가

### DIFF
--- a/baro-auth/src/main/java/com/barofarm/auth/infrastructure/config/SecurityConfig.java
+++ b/baro-auth/src/main/java/com/barofarm/auth/infrastructure/config/SecurityConfig.java
@@ -55,9 +55,17 @@ public class SecurityConfig {
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         // 1) 완전 공개 URL
-                        .requestMatchers("/auth/login", "/auth/signup", "/auth/refresh", "/auth/logout",
-                                "/auth/verification/**", "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs",
-                                "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**", "/configuration/**")
+                        .requestMatchers(
+                            "/api/v1/auth/login",
+                            "/api/v1/auth/signup",
+                            "/api/v1/auth/refresh",
+                            "/api/v1/auth/logout",
+                            "/api/v1/auth/verification/**",
+                            "/swagger-ui/**",
+                            "/swagger-ui.html",
+                            "/v3/api-docs",
+                            "/v3/api-docs/**",
+                            "/swagger-resources/**", "/webjars/**", "/configuration/**")
                         .permitAll()
                         // 2) 나머지는 인증 필요
                         .anyRequest().authenticated())


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요 (예: #123) -->
- #48 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요 -->

바뀐 url기준으로 auth내 permit 항목을 업데이트 했습니다.

## 🎯 변경된 서비스
<!-- 해당하는 서비스에 체크해주세요 -->
- [X] auth-service
- [ ] buyer-service
- [ ] cart-service
- [ ] product-service
- [ ] seller-service
- [ ] farm-service
- [ ] order-service
- [ ] payment-service
- [ ] settlement-service
- [ ] delivery-service
- [ ] notification-service
- [ ] experience-service
- [ ] search-service
- [ ] review-service
- [ ] gateway-service
- [ ] config-server
- [ ] eureka-server

## ✅ 체크리스트
<!-- 완료한 항목에 체크해주세요 -->
- [X] 린트 검사 통과 (`./gradlew lint`)
- [X] 코드 포맷팅 완료 (`./gradlew format`)
- [X] 테스트 통과 (`./gradlew test`)
- [ ] 문서 업데이트 (필요한 경우)

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 💬 리뷰어에게
<!-- 리뷰어가 중점적으로 봐야 할 부분이 있다면 적어주세요 -->




