### PR TITLE
[Fix] #87 - kafka 재시도 및 DLQ 로직 누락 수정

### DIFF
--- a/baro-ai/src/main/resources/application.yml
+++ b/baro-ai/src/main/resources/application.yml
@@ -27,32 +27,10 @@ spring:
       group-id: ai-service
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
-      properties:
-        spring.json.trusted.packages: "*"
-        # 재연결 설정
-        reconnect.backoff.ms: 50          # 재연결 시 초기 백오프 시간 (50ms)
-        reconnect.backoff.max.ms: 1000     # 재연결 시 최대 백오프 시간 (1초)
-        # 세션 및 하트비트 설정
-        session.timeout.ms: 30000          # 세션 타임아웃 (30초)
-        heartbeat.interval.ms: 3000        # 하트비트 간격 (3초)
-        # 폴링 및 요청 타임아웃 설정
-        max.poll.interval.ms: 300000       # 최대 폴링 간격 (5분)
-        request.timeout.ms: 30000          # 요청 타임아웃 (30초)
-        # 메타데이터 갱신 설정
-        metadata.max.age.ms: 300000        # 메타데이터 최대 유지 시간 (5분)
-        # 연결 재시도 설정
-        connections.max.idle.ms: 540000    # 최대 유휴 연결 시간 (9분)
       auto-offset-reset: latest  # earliest에서 latest로 변경하여 오래된 메시지 건너뛰기
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-    listener:
-      # Consumer 재시작 설정
-      auto-startup: true                   # 자동 시작
-      # 에러 처리 설정
-      ack-mode: batch                      # 배치 단위로 커밋
-      # 재시도 설정
-      concurrency: 1                       # 동시 Consumer 스레드 수
 
   # Spring AI 설정
   ai:

--- a/baro-buyer/src/main/resources/application.yml
+++ b/baro-buyer/src/main/resources/application.yml
@@ -14,8 +14,8 @@ spring:
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:mysql://baro-mysql:3306/${MYSQL_DATABASE:-barobuyer}?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&useUnicode=true}
     driver-class-name: com.mysql.cj.jdbc.Driver
-    username: ${MYSQL_USER:barouser}
-    password: ${MYSQL_PASSWORD:baroUser123!!123!!}
+    username: ${MYSQL_USER:}
+    password: ${MYSQL_PASSWORD:}
   jpa:
     hibernate:
       ddl-auto: update  # 일시적으로 update로 변경 (스키마 수정 후 validate로 변경)
@@ -32,11 +32,6 @@ spring:
       group-id: support-service
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
-      properties:
-        spring.json.trusted.packages: "*"
-        spring.json.type.mapping: productEvent:com.barofarm.support.event.ProductEvent
-        spring.json.use.type.headers: false
-        spring.json.value.default.type: com.barofarm.support.event.ProductEvent
       auto-offset-reset: latest  # earliest에서 latest로 변경하여 오래된 메시지 건너뛰기
       # auto-offset-reset: earliest
     producer:

--- a/baro-order/src/main/resources/application.yml
+++ b/baro-order/src/main/resources/application.yml
@@ -42,11 +42,6 @@ spring:
       group-id: support-service
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
-      properties:
-        spring.json.trusted.packages: "*"
-        spring.json.type.mapping: productEvent:com.barofarm.support.event.ProductEvent
-        spring.json.use.type.headers: false
-        spring.json.value.default.type: com.barofarm.support.event.ProductEvent
       auto-offset-reset: latest  # earliest에서 latest로 변경하여 오래된 메시지 건너뛰기
       # auto-offset-reset: earliest
     # producer:

--- a/baro-seller/src/main/java/com/barofarm/seller/farm/infrastructure/kafka/FarmEventProducer.java
+++ b/baro-seller/src/main/java/com/barofarm/seller/farm/infrastructure/kafka/FarmEventProducer.java
@@ -1,10 +1,14 @@
 package com.barofarm.seller.farm.infrastructure.kafka;
 
 import com.barofarm.seller.farm.event.FarmEvent;
+import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Component;
+import org.springframework.util.backoff.BackOffExecution;
+import org.springframework.util.backoff.ExponentialBackOff;
 
 @Slf4j
 @Component
@@ -12,9 +16,17 @@ import org.springframework.stereotype.Component;
 public class FarmEventProducer {
 
     private final KafkaTemplate<String, FarmEvent> kafkaTemplate;
+    private final KafkaTemplate<String, Object> producerDlqKafkaTemplate;
 
     private static final String TOPIC = "farm-events";
+    private static final String PRODUCER_DLQ_TOPIC = "farm-events.producer.DLQ";
 
+    /**
+     * Farm 이벤트를 Kafka 토픽으로 전송
+     * - 지수 백오프를 사용한 재시도 (초기 1초, 배수 2.0)
+     * - 최대 1번 재시도 (maxElapsedTime으로 제한)
+     * - 재시도 실패 시 DLQ(Dead Letter Queue) 토픽으로 메시지 전송
+     */
     public void send(FarmEvent event) {
         FarmEvent.FarmEventData data = event.getData();
         // 파티션 키로 farmId를 사용하여 동일 farm의 이벤트 순서 보장
@@ -24,19 +36,94 @@ public class FarmEventProducer {
             "📤 [PRODUCER] Sending farm event to topic '{}' - Type: {}, Farm ID: {}, Seller ID: {}, Partition Key: {}",
             TOPIC, event.getType(), data.getFarmId(), data.getSellerId(), partitionKey);
 
-        kafkaTemplate.send(TOPIC, partitionKey, event).whenComplete((result, ex) -> {
+        // 지수 백오프 설정: 초기 간격 1초, 배수 2.0
+        ExponentialBackOff backOff = new ExponentialBackOff();
+        backOff.setInitialInterval(1000L); // 초기 간격: 1초
+        backOff.setMultiplier(2.0); // 배수: 2.0 (1초 -> 2초 -> 4초 -> ...)
+        backOff.setMaxInterval(10000L); // 최대 간격: 10초
+        // 최대 경과 시간을 초기 간격보다 크고 두 번째 재시도 전에 끝나도록 설정 (최대 1번 재시도)
+        backOff.setMaxElapsedTime(1500L); // 최대 경과 시간: 1.5초 (1번 재시도만 허용)
+
+        sendWithRetry(event, partitionKey, backOff.start());
+    }
+
+    /**
+     * 지수 백오프를 사용한 재시도 로직
+     */
+    private void sendWithRetry(FarmEvent event, String partitionKey, BackOffExecution backOffExecution) {
+        CompletableFuture<SendResult<String, FarmEvent>> future = 
+            kafkaTemplate.send(TOPIC, partitionKey, event);
+
+        future.whenComplete((result, ex) -> {
             if (ex == null) {
                 log.info(
                     "✅ [PRODUCER] Successfully sent farm event to topic '{}' - Type: {}, Farm ID: {}, "
                         + "Partition: {}, Offset: {}, Partition Key: {}",
-                    TOPIC, event.getType(), data.getFarmId(),
+                    TOPIC, event.getType(), event.getData().getFarmId(),
                     result.getRecordMetadata().partition(), result.getRecordMetadata().offset(), partitionKey);
             } else {
-                log.error(
-                    "❌ [PRODUCER] Failed to send farm event to topic '{}' - Type: {}, Farm ID: {}, "
-                        + "Partition Key: {}, Error: {}",
-                    TOPIC, event.getType(), data.getFarmId(), partitionKey, ex.getMessage(), ex);
+                // 재시도 가능 여부 확인
+                long nextBackOff = backOffExecution.nextBackOff();
+                if (nextBackOff != BackOffExecution.STOP) {
+                    // 재시도 가능: 지수 백오프 대기 후 재시도
+                    log.warn(
+                        "⚠️ [PRODUCER] Failed to send farm event, retrying after {}ms - "
+                            + "Topic: {}, Type: {}, Farm ID: {}, Partition Key: {}, Error: {}",
+                        nextBackOff, TOPIC, event.getType(), event.getData().getFarmId(), 
+                        partitionKey, ex.getMessage());
+                    
+                    try {
+                        Thread.sleep(nextBackOff);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        log.error("❌ [PRODUCER] Retry sleep interrupted", ie);
+                        sendToDlq(event, partitionKey, ex);
+                        return;
+                    }
+                    
+                    // 재시도
+                    sendWithRetry(event, partitionKey, backOffExecution);
+                } else {
+                    // 재시도 불가: DLQ로 전송
+                    log.error(
+                        "❌ [PRODUCER] Failed to send farm event after retries - "
+                            + "Topic: {}, Type: {}, Farm ID: {}, Partition Key: {}, Error: {}",
+                        TOPIC, event.getType(), event.getData().getFarmId(), partitionKey, ex.getMessage(), ex);
+                    sendToDlq(event, partitionKey, ex);
+                }
             }
         });
+    }
+
+    /**
+     * DLQ로 메시지 전송
+     */
+    private void sendToDlq(FarmEvent event, String partitionKey, Throwable originalException) {
+        try {
+            producerDlqKafkaTemplate.send(PRODUCER_DLQ_TOPIC, partitionKey, event)
+                .whenComplete((dlqResult, dlqEx) -> {
+                    if (dlqEx == null) {
+                        log.error(
+                            "💀 [PRODUCER_DLQ] Failed message sent to Producer DLQ - "
+                                + "Original Topic: {}, DLQ Topic: {}, Type: {}, Farm ID: {}, "
+                                + "Partition: {}, Offset: {}",
+                            TOPIC, PRODUCER_DLQ_TOPIC, event.getType(), event.getData().getFarmId(),
+                            dlqResult.getRecordMetadata().partition(), 
+                            dlqResult.getRecordMetadata().offset());
+                    } else {
+                        log.error(
+                            "💀 [PRODUCER_DLQ] CRITICAL: Failed to send to Producer DLQ - "
+                                + "Original Topic: {}, DLQ Topic: {}, Type: {}, Farm ID: {}, Error: {}",
+                            TOPIC, PRODUCER_DLQ_TOPIC, event.getType(), event.getData().getFarmId(), 
+                            dlqEx.getMessage(), dlqEx);
+                    }
+                });
+        } catch (Exception dlqException) {
+            log.error(
+                "💀 [PRODUCER_DLQ] CRITICAL: Exception while sending to Producer DLQ - "
+                    + "Original Topic: {}, DLQ Topic: {}, Type: {}, Farm ID: {}, Error: {}",
+                TOPIC, PRODUCER_DLQ_TOPIC, event.getType(), event.getData().getFarmId(), 
+                dlqException.getMessage(), dlqException);
+        }
     }
 }

--- a/baro-seller/src/main/java/com/barofarm/seller/farm/infrastructure/kafka/KafkaProducerConfig.java
+++ b/baro-seller/src/main/java/com/barofarm/seller/farm/infrastructure/kafka/KafkaProducerConfig.java
@@ -46,4 +46,21 @@ public class KafkaProducerConfig {
     public KafkaTemplate<String, FarmEvent> farmEventKafkaTemplate() {
         return new KafkaTemplate<>(farmEventProducerFactory());
     }
+
+    /**
+     * Producer DLQ(Dead Letter Queue)용 KafkaTemplate 생성
+     * Producer가 메시지 전송 실패 시 DLQ 토픽으로 전송하기 위해 사용
+     */
+    @Bean
+    public KafkaTemplate<String, Object> producerDlqKafkaTemplate() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        config.put(ProducerConfig.ACKS_CONFIG, "1"); 
+        config.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true); // 중복 방지
+        
+        ProducerFactory<String, Object> producerFactory = new DefaultKafkaProducerFactory<>(config);
+        return new KafkaTemplate<>(producerFactory);
+    }
 }

--- a/baro-seller/src/main/resources/application.yml
+++ b/baro-seller/src/main/resources/application.yml
@@ -32,11 +32,6 @@ spring:
       group-id: support-service
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
-      properties:
-        spring.json.trusted.packages: "*"
-        spring.json.type.mapping: productEvent:com.barofarm.support.event.ProductEvent
-        spring.json.use.type.headers: false
-        spring.json.value.default.type: com.barofarm.support.event.ProductEvent
       auto-offset-reset: latest  # earliest에서 latest로 변경하여 오래된 메시지 건너뛰기
       # auto-offset-reset: earliest
     producer:

--- a/baro-support/src/main/java/com/barofarm/support/config/KafkaConsumerConfig.java
+++ b/baro-support/src/main/java/com/barofarm/support/config/KafkaConsumerConfig.java
@@ -1,7 +1,6 @@
 package com.barofarm.support.config;
 
-import java.util.HashMap;
-import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -19,8 +18,11 @@ import org.springframework.kafka.listener.CommonErrorHandler;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.util.backoff.ExponentialBackOff;
+import java.util.HashMap;
+import java.util.Map;
 
 /** Kafka Consumer 설정 */
+@Slf4j
 @Configuration
 public class KafkaConsumerConfig {
 
@@ -41,7 +43,7 @@ public class KafkaConsumerConfig {
         config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
             org.springframework.kafka.support.serializer.JsonSerializer.class);
-        config.put(ProducerConfig.ACKS_CONFIG, "1"); // 메시지 손실 방지
+        config.put(ProducerConfig.ACKS_CONFIG, "1");
         config.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true); // 중복 방지
         
         ProducerFactory<String, Object> producerFactory = new DefaultKafkaProducerFactory<>(config);
@@ -116,6 +118,9 @@ public class KafkaConsumerConfig {
         // 파티션당 1개 스레드로 처리하여 순서 보장
         // Producer에서 파티션 키를 사용하므로 동일 farm의 이벤트는 같은 파티션에 들어감
         factory.setConcurrency(1);
+        // 배치 단위로 offset 커밋 (성능 최적화)
+        factory.getContainerProperties().setAckMode(
+            org.springframework.kafka.listener.ContainerProperties.AckMode.BATCH);
         return factory;
     }
 }

--- a/baro-support/src/main/java/com/barofarm/support/event/ReservationEvent.java
+++ b/baro-support/src/main/java/com/barofarm/support/event/ReservationEvent.java
@@ -1,6 +1,5 @@
-package com.barofarm.ai.search.infrastructure.event;
+package com.barofarm.support.event;
 
-import java.math.BigInteger;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.UUID;
@@ -36,7 +35,7 @@ public class ReservationEvent {
         private LocalDate reservedDate;
         private String reservedTimeSlot;
         private Integer headCount;
-        private BigInteger totalPrice;
+        private Long totalPrice;
         private String status;
         private Instant createdAt;
     }

--- a/baro-support/src/main/java/com/barofarm/support/experience/infrastructure/kafka/DlqEventConsumer.java
+++ b/baro-support/src/main/java/com/barofarm/support/experience/infrastructure/kafka/DlqEventConsumer.java
@@ -1,0 +1,49 @@
+package com.barofarm.support.experience.infrastructure.kafka;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * DLQ(Dead Letter Queue) 토픽을 구독하여 실패한 메시지를 모니터링하는 Consumer
+ * 
+ * 목적: DLQ로 전송된 메시지를 로그로 확인하여 문제를 추적
+ * 
+ * DLQ 토픽 명명 규칙:
+ * - Consumer DLQ: 원본 토픽명 + ".DLQ" (예: "farm-events" → "farm-events.DLQ")
+ * - Producer DLQ: 원본 토픽명 + ".producer.DLQ" (예: "farm-events" → "farm-events.producer.DLQ")
+ */
+@Slf4j
+@Component
+public class DlqEventConsumer {
+
+    /**
+     * farm-events.DLQ 토픽 구독 (Consumer 처리 실패용)
+     * Consumer가 메시지 처리 실패 후 재시도도 실패한 경우
+     */
+    @KafkaListener(topics = "farm-events.DLQ", groupId = "support-service-dlq")
+    public void handleFarmEventDlq(ConsumerRecord<String, Object> record) {
+        log.error(
+            "💀 [DLQ_MONITOR] Failed message received from Consumer DLQ - "
+                + "Topic: {}, Partition: {}, Offset: {}, Key: {}, Value: {}",
+            record.topic(), record.partition(), record.offset(), record.key(), record.value());
+        
+        // TODO: 필요시 여기에 알림 발송, 메트릭 수집 등의 로직 추가 예정
+    }
+
+    /**
+     * farm-events.producer.DLQ 토픽 구독 (Producer 전송 실패용)
+     * Producer가 메시지 전송 실패 후 재시도도 실패한 경우
+     */
+    @KafkaListener(topics = "farm-events.producer.DLQ", groupId = "support-service-producer-dlq")
+    public void handleFarmEventProducerDlq(ConsumerRecord<String, Object> record) {
+        log.error(
+            "💀 [PRODUCER_DLQ_MONITOR] Failed message received from Producer DLQ - "
+                + "Topic: {}, Partition: {}, Offset: {}, Key: {}, Value: {}",
+            record.topic(), record.partition(), record.offset(), record.key(), record.value());
+        
+        // TODO: 필요시 여기에 알림 발송, 메트릭 수집 등의 로직 추가 예정
+    }
+
+}

--- a/baro-support/src/main/resources/application.yml
+++ b/baro-support/src/main/resources/application.yml
@@ -52,33 +52,8 @@ spring:
       group-id: support-service
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
-      properties:
-        spring.json.trusted.packages: "*"
-        spring.json.type.mapping: productEvent:com.barofarm.support.search.infrastructure.event.ProductEvent
-        spring.json.use.type.headers: false
-        spring.json.value.default.type: com.barofarm.support.search.infrastructure.event.ProductEvent
-        # 재연결 설정
-        reconnect.backoff.ms: 50          # 재연결 시 초기 백오프 시간 (50ms)
-        reconnect.backoff.max.ms: 1000    # 재연결 시 최대 백오프 시간 (1초)
-        # 세션 및 하트비트 설정
-        session.timeout.ms: 30000          # 세션 타임아웃 (30초)
-        heartbeat.interval.ms: 3000        # 하트비트 간격 (3초)
-        # 폴링 및 요청 타임아웃 설정
-        max.poll.interval.ms: 300000       # 최대 폴링 간격 (5분)
-        request.timeout.ms: 30000          # 요청 타임아웃 (30초)
-        # 메타데이터 갱신 설정
-        metadata.max.age.ms: 300000        # 메타데이터 최대 유지 시간 (5분)
-        # 연결 재시도 설정
-        connections.max.idle.ms: 540000    # 최대 유휴 연결 시간 (9분)
       auto-offset-reset: latest  # earliest에서 latest로 변경하여 오래된 메시지 건너뛰기
       # auto-offset-reset: earliest
-    listener:
-      # Consumer 재시작 설정
-      auto-startup: true                   # 자동 시작
-      # 에러 처리 설정
-      ack-mode: batch                      # 배치 단위로 커밋
-      # 재시도 설정
-      concurrency: 1                       # 동시 Consumer 스레드 수
 
 eureka:
   client:


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요 (예: #123) -->
- closes #87

## 📝 작업 내용
kafka 재시도 로직 누락
kafka DLQ 로직 누락

## 🎯 변경된 서비스
<!-- 해당하는 서비스에 체크해주세요 -->
- [ ] auth-service
- [ ] buyer-service
- [ ] cart-service
- [ ] product-service
- [ ] seller-service
- [x] farm-service
- [ ] order-service
- [ ] payment-service
- [ ] settlement-service
- [ ] delivery-service
- [ ] notification-service
- [x] experience-service
- [ ] search-service
- [ ] review-service
- [ ] gateway-service
- [ ] config-server
- [ ] eureka-server

## ✅ 체크리스트
<!-- 완료한 항목에 체크해주세요 -->
- [x] 린트 검사 통과 (`./gradlew lint`)
- [x] 코드 포맷팅 완료 (`./gradlew format`)
- [ ] 테스트 통과 (`./gradlew test`)
- [ ] 문서 업데이트 (필요한 경우)

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 💬 리뷰어에게
<!-- 리뷰어가 중점적으로 봐야 할 부분이 있다면 적어주세요 -->




